### PR TITLE
Fix flacky storybook tests

### DIFF
--- a/integrations/storybook/src/capture.ts
+++ b/integrations/storybook/src/capture.ts
@@ -46,14 +46,24 @@ export async function captureStories({
 
   await Promise.race([
     page
-      .waitForFunction(() => (window as SBWindow).__STORYBOOK_CLIENT_API__, {
-        timeout: 60_000,
-      })
+      .waitForFunction(
+        () =>
+          (window as SBWindow).__STORYBOOK_CLIENT_API__._storyStore!
+            .cacheAllCSFFiles,
+        {
+          timeout: 60_000,
+        }
+      )
       .catch(() => {}),
     page
-      .waitForFunction(() => (window as SBWindow).__STORYBOOK_PREVIEW__, {
-        timeout: 60_000,
-      })
+      .waitForFunction(
+        () =>
+          (window as SBWindow).__STORYBOOK_PREVIEW__.storyStoreValue!
+            .cacheAllCSFFiles,
+        {
+          timeout: 60_000,
+        }
+      )
       .catch(() => {}),
   ]);
 


### PR DESCRIPTION
Storybook tests are flackly when attempting to initially read all the stories.

I believe it's down to our race condition which on v8 of storybook can resolve sooner than we require.

Testing steps
- [ ] Test on v8 storybook
- [ ] Testing on v7 storybook


Closes #301 

