### PR TITLE
Reworking postgres init script

### DIFF
--- a/docker/config/Dockerfile.psql
+++ b/docker/config/Dockerfile.psql
@@ -1,0 +1,4 @@
+from postgres:16
+
+# Copy the Init script
+COPY ./init-user-db.sh /docker-entrypoint-initdb.d/

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -21,7 +21,9 @@ services:
       - MINIO_ROOT_PASSWORD=CHANGEME
       - MINIO_DEFAULT_BUCKETS=pixeleye
   postgres:
-    image: postgres:latest
+    build:
+      context: ./config
+      dockerfile: ./Dockerfile.psql
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data

--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -27,9 +27,6 @@ services:
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data
-      - type: bind
-        source: ./config/init-user-db.sh
-        target: /docker-entrypoint-initdb.d/init-user-db.sh
 
     environment:
       - POSTGRES_USER=guest

--- a/docker/docker-compose-self-hosting.yml
+++ b/docker/docker-compose-self-hosting.yml
@@ -26,9 +26,6 @@ services:
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data
-      - type: bind
-        source: ./config/init-user-db.sh
-        target: /docker-entrypoint-initdb.d/init-user-db.sh
 
     environment:
       - POSTGRES_USER=guest

--- a/docker/docker-compose-self-hosting.yml
+++ b/docker/docker-compose-self-hosting.yml
@@ -20,7 +20,9 @@ services:
       - MINIO_ROOT_PASSWORD=CHANGEME
       - MINIO_DEFAULT_BUCKETS=pixeleye
   postgres:
-    image: postgres:latest
+    build:
+      context: ./config
+      dockerfile: ./Dockerfile.psql
     restart: unless-stopped
     volumes:
       - postgres-data:/var/lib/postgresql/data

--- a/docs/04-guides/01-self-hosting.md
+++ b/docs/04-guides/01-self-hosting.md
@@ -26,7 +26,8 @@ This docker file requires the files found in this [config folder](https://github
 ### Quick start
 
 1. Copy `docker-compose-self-hosting.yml` & `config` folder to your server.
-2. run `docker compose -f docker-compose-self-hosting.yml up`
+2. Run `docker compose -f docker-compose-self-hosting.yml up`.
+3. After docker has started, you can access Pixeleye at `http://localhost:3000`.
 
 ### Changing secrets
 

--- a/docs/04-guides/01-self-hosting.md
+++ b/docs/04-guides/01-self-hosting.md
@@ -26,7 +26,7 @@ This docker file requires the files found in this [config folder](https://github
 ### Quick start
 
 1. Copy [`docker-compose-self-hosting.yml`](https://github.com/pixeleye-io/pixeleye/tree/main/docker/docker-compose-self-hosting.yml) & everything from [`./config`](https://github.com/pixeleye-io/pixeleye/tree/main/docker/config) to your server.
-2. run `docker compose -f docker-compose-self-hosting.yml up`
+2. Run `docker compose -f docker-compose-self-hosting.yml up`
 3. After docker has started, you can access Pixeleye at `http://localhost:3000`.
 
 > Make sure you have the [./config folder](https://github.com/pixeleye-io/pixeleye/tree/main/docker/config) folder in the same directory as the docker-compose file.


### PR DESCRIPTION
Fixes #318 

I've reworked our postgres init script to use a dockerfile rather than copying the files via docker-compose. This should avoid any host permission issues.

